### PR TITLE
fix turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'bootstrap-sass', '~> 3.3.6'
 gem 'redcarpet'
 gem 'coderay'
+gem 'jquery-turbolinks'
 
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,9 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     launchy (2.4.3)
       addressable (~> 2.3)
     listen (3.0.8)
@@ -218,6 +221,7 @@ DEPENDENCIES
   factory_girl_rails
   jbuilder (~> 2.5)
   jquery-rails
+  jquery-turbolinks
   launchy
   listen (~> 3.0.5)
   pg (~> 0.18)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //
 //= require jquery
 //= bootstrap-sprockets
+//= require jquery.turbolinks
 //= require jquery_ujs
 //= require turbolinks
 //= require_tree .


### PR DESCRIPTION
why didn't I --skip turbolinks with rails new?
jQuery functions work, but a little buggy and need page refresh